### PR TITLE
refactor: Use js-yaml directly to load theme YAML rather than loading ha-yaml-editor via surrogate tools event tab.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@watchable/unpromise": "^1.0.2",
         "color-name": "^2.1.1",
         "compare-versions": "^6.1.1",
+        "js-yaml": "^5.2.3",
         "lit": "^3.3.3",
         "memoize-one": "^6.0.0",
         "parse-duration": "^2.1.8"
@@ -5593,7 +5594,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/argv-formatter": {
@@ -6207,6 +6207,29 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/cross-spawn": {
@@ -7177,10 +7200,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
-      "dev": true,
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.3.tgz",
+      "integrity": "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==",
       "funding": [
         {
           "type": "github",
@@ -7196,7 +7218,7 @@
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/jsesc": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@watchable/unpromise": "^1.0.2",
     "color-name": "^2.1.1",
     "compare-versions": "^6.1.1",
+    "js-yaml": "^5.2.3",
     "lit": "^3.3.3",
     "memoize-one": "^6.0.0",
     "parse-duration": "^2.1.8"

--- a/src/helpers/themes.ts
+++ b/src/helpers/themes.ts
@@ -88,9 +88,9 @@ export async function get_theme(root: Uix): Promise<UixStyle> {
       root.debug && console.log("UIX Debug: Effective UIX Theme:", uixTheme);
 
       if (themes[uixTheme][`uix-${root.type}-yaml`]) {
-        return yaml2json(`uix-${root.type}-yaml`, themes[uixTheme][`uix-${root.type}-yaml`]);
+        return await yaml2json(`uix-${root.type}-yaml`, themes[uixTheme][`uix-${root.type}-yaml`]) as UixStyle;
       } else if (themes[uixTheme][`card-mod-${root.type}-yaml`]) {
-        return yaml2json(`card-mod-${root.type}-yaml`, themes[uixTheme][`card-mod-${root.type}-yaml`]);
+        return await yaml2json(`card-mod-${root.type}-yaml`, themes[uixTheme][`card-mod-${root.type}-yaml`]) as UixStyle;
       } else if (themes[uixTheme][`uix-${root.type}`]) {
         return { ".": themes[uixTheme][`uix-${root.type}`] };
       } else if (themes[uixTheme][`card-mod-${root.type}`]) {
@@ -129,7 +129,7 @@ export async function get_theme_macros(root: Uix): Promise<Record<string, MacroC
 
       if (themes[uixTheme]["uix-macros-yaml"]) {
         try {
-          return await yaml2json(`uix-macros-yaml`, themes[uixTheme]["uix-macros-yaml"]) ?? {};
+          return (await yaml2json(`uix-macros-yaml`, themes[uixTheme]["uix-macros-yaml"]) as Record<string, MacroConfig | string>) ?? {};
         } catch (e) {
           console.error("UIX: Error parsing uix-macros-yaml from theme:", uixTheme, e);
           return {};

--- a/src/helpers/themes.ts
+++ b/src/helpers/themes.ts
@@ -88,9 +88,9 @@ export async function get_theme(root: Uix): Promise<UixStyle> {
       root.debug && console.log("UIX Debug: Effective UIX Theme:", uixTheme);
 
       if (themes[uixTheme][`uix-${root.type}-yaml`]) {
-        return yaml2json(themes[uixTheme][`uix-${root.type}-yaml`]);
+        return yaml2json(`uix-${root.type}-yaml`, themes[uixTheme][`uix-${root.type}-yaml`]);
       } else if (themes[uixTheme][`card-mod-${root.type}-yaml`]) {
-        return yaml2json(themes[uixTheme][`card-mod-${root.type}-yaml`]);
+        return yaml2json(`card-mod-${root.type}-yaml`, themes[uixTheme][`card-mod-${root.type}-yaml`]);
       } else if (themes[uixTheme][`uix-${root.type}`]) {
         return { ".": themes[uixTheme][`uix-${root.type}`] };
       } else if (themes[uixTheme][`card-mod-${root.type}`]) {
@@ -129,7 +129,7 @@ export async function get_theme_macros(root: Uix): Promise<Record<string, MacroC
 
       if (themes[uixTheme]["uix-macros-yaml"]) {
         try {
-          return await yaml2json(themes[uixTheme]["uix-macros-yaml"]) ?? {};
+          return await yaml2json(`uix-macros-yaml`, themes[uixTheme]["uix-macros-yaml"]) ?? {};
         } catch (e) {
           console.error("UIX: Error parsing uix-macros-yaml from theme:", uixTheme, e);
           return {};

--- a/src/helpers/yaml2json.ts
+++ b/src/helpers/yaml2json.ts
@@ -1,15 +1,25 @@
-import { load, YAML11_SCHEMA } from 'js-yaml'
+import { load, YAML11_SCHEMA, YAMLException } from 'js-yaml'
 
 export const yaml2json = async (key, yaml) => {
   try {
-    const parsed = load(yaml, { schema: YAML11_SCHEMA }) as Record<string, any>;
+    const parsed = load(yaml, { schema: YAML11_SCHEMA });
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("Expected YAML document root to be a mapping");
+    }
     return parsed;
-  } catch (error: any) {
-    const errorMessage = `${error.reason}${error.mark ? ` at line ${error.mark.line + 1}, column ${error.mark.column + 1}` : ''}`;
+  } catch (error: unknown) {
+    const mark = error instanceof YAMLException ? error.mark : undefined;
+    const reason =
+      error instanceof YAMLException
+        ? error.reason
+        : error instanceof Error
+          ? error.message
+          : String(error);
+    const errorMessage = `${reason}${mark ? ` at line ${mark.line + 1}, column ${mark.column + 1}` : ''}`;
     console.groupCollapsed(`UIX: Error loading ${key}`);
     console.log(errorMessage);
     console.log(
-      yaml.split('\n').map((line: any, i: number) => `${i == error.mark?.line ? '>>' : '  '}${i + 1}: ${line}`).join('\n')
+      yaml.split('\n').map((line: any, i: number) => `${i === mark?.line ? '>>' : '  '}${i + 1}: ${line}`).join('\n')
     );
     console.groupEnd();
     return {};

--- a/src/helpers/yaml2json.ts
+++ b/src/helpers/yaml2json.ts
@@ -1,69 +1,17 @@
-let _yaml2jsonLoadPromise: Promise<void> | null = null;
+import { load, YAML11_SCHEMA } from 'js-yaml'
 
-const _load_yaml2json = async () => {
-  if (customElements.get("tools-event")) return;
-  if (_yaml2jsonLoadPromise) return _yaml2jsonLoadPromise;
-
-  _yaml2jsonLoadPromise = (async () => {
-    try {
-      await customElements.whenDefined("partial-panel-resolver");
-      const ppr: any = document.createElement("partial-panel-resolver");
-
-      ppr.hass = {
-        panels: [
-          {
-            url_path: "tmp",
-            component_name: "config",
-          },
-        ],
-        auth: {
-          data: {
-            hassUrl: location.origin,
-          }
-        }
-      };
-      ppr._updateRoutes();
-
-      await ppr.routerOptions.routes.tmp.load();
-      await customElements.whenDefined("ha-panel-config");
-      const hpc: any = document.createElement("ha-panel-config");
-      // Home Assistant Developer Tools panel renamed to Tools panel in 2026.8.0
-      if (hpc.routerOptions.routes['developer-tools']) {
-        await hpc.routerOptions.routes['developer-tools']?.load();
-        await customElements.whenDefined("developer-tools-router");
-        const dtr: any = document.createElement("developer-tools-router");
-        await dtr.routerOptions.routes.event.load();
-      } else if (hpc.routerOptions.routes['tools']) {
-        await hpc.routerOptions.routes['tools']?.load();
-        await customElements.whenDefined("tools-router");
-        const tr: any = document.createElement("tools-router");
-        await tr.routerOptions.routes.event.load();
-      } else {
-        console.error("UIX: Error loading yaml2json: Could not find developer-tools or tools route");
-      }
-    } catch (err) {
-      console.error("UIX: Error loading yaml2json:", err);
-    }
-  })();
-
-  return _yaml2jsonLoadPromise;
-};
-
-export const yaml2json = async (yaml) => {
-  await _load_yaml2json();
-  const el: any = document.createElement("ha-yaml-editor");
-  if ('hass' in el) {
-    el.hass = {};
-    el.hass.localize = (any) => "Invalid YAML";
-  } else {
-    el._i18n = { localize: (any) => "Invalid YAML" };
-  }
-  el._onChange(new CustomEvent("yaml", { detail: { value: yaml } }));
-  if (!el.isValid) {
-    console.groupCollapsed("UIX: Error loading theme yaml");
-    console.error(yaml);
+export const yaml2json = async (key, yaml) => {
+  try {
+    const parsed = load(yaml, { schema: YAML11_SCHEMA }) as Record<string, any>;
+    return parsed;
+  } catch (error: any) {
+    const errorMessage = `${error.reason}${error.mark ? ` at line ${error.mark.line + 1}, column ${error.mark.column + 1}` : ''}`;
+    console.groupCollapsed(`UIX: Error loading ${key}`);
+    console.log(errorMessage);
+    console.log(
+      yaml.split('\n').map((line: any, i: number) => `${i == error.mark?.line ? '>>' : '  '}${i + 1}: ${line}`).join('\n')
+    );
     console.groupEnd();
     return {};
   }
-  return el.value;
 };


### PR DESCRIPTION
Fixes: #518