### PR TITLE
fix: Multiple template subscriptions make be created for same UIX Styling node when Home Assistant app is suspended and restored in Browser. This causes multiple updates to the UIX Styling node when the template updates which may cause visual artifacts and will add up to a small resource increase over time.

### DIFF
--- a/src/helpers/templates.ts
+++ b/src/helpers/templates.ts
@@ -194,7 +194,10 @@ export function unbind_template(
         // which will match the same template and variables and cause multiple callbacks to be called for the same template update.
         // So when document is hidden we unsubscribe immediately instead of waiting for the cooldown.
         if (document.hidden) {
-          window.setTimeout(() => unsubscribe_template(key, true), 0);
+          cache.cooldownTimeoutID = window.setTimeout(
+            () => unsubscribe_template(key, true),
+            0
+          );
           return;
         }
         cache.cooldownTimeoutID = window.setTimeout(

--- a/src/helpers/templates.ts
+++ b/src/helpers/templates.ts
@@ -194,17 +194,22 @@ export function unbind_template(
         // which will match the same template and variables and cause multiple callbacks to be called for the same template update.
         // So when document is hidden we unsubscribe immediately instead of waiting for the cooldown.
         if (document.hidden) {
-          cache.cooldownTimeoutID = window.setTimeout(
-            () => unsubscribe_template(key, true),
-            0
-          );
+          delete cachedTemplates[key];
+          console.groupCollapsed("UIX: Unsubscribing template immediately due to document hidden");
+          console.log( { 
+            template: cache.template, 
+            variables: cache.variables,
+            includesIconVars: cache.includesIconVars,
+            includesImageVars: cache.includesImageVars,
+          });
+          console.groupEnd();
+          cache.unsubscribe.then((unsubscribe) => unsubscribe());
           return;
         }
         cache.cooldownTimeoutID = window.setTimeout(
           unsubscribe_template,
           20000,
-          key,
-          false
+          key
         );
       }
       break;
@@ -212,18 +217,14 @@ export function unbind_template(
   }
 }
 
-async function unsubscribe_template(key: string, immediate = false) {
+async function unsubscribe_template(key: string) {
   const cache = cachedTemplates[key];
   if (!cache) return;
   if (cache.cooldownTimeoutID) {
     clearTimeout(cache.cooldownTimeoutID);
   }
   if (cache.debug) {
-    console.groupCollapsed(
-      immediate ? 
-      "UIX: Unsubscribing template immediately" : 
-      "UIX: Unsubscribing template after cooldown"
-    );
+    console.groupCollapsed("UIX: Unsubscribing template after cooldown");
     console.log( { 
       template: cache.template, 
       variables: cache.variables,

--- a/src/helpers/templates.ts
+++ b/src/helpers/templates.ts
@@ -188,10 +188,20 @@ export function unbind_template(
           });
           console.groupEnd();
         }
+        // When hidden partial-panel-resolver disconnects the view
+        // The app may also be suspending so we can't delay unsubscribe as it won't happen until 
+        // after hass.connection is suspended causing the unsubscribe to never happen and lead to duplicate subscriptions 
+        // which will match the same template and variables and cause multiple callbacks to be called for the same template update.
+        // So when document is hidden we unsubscribe immediately instead of waiting for the cooldown.
+        if (document.hidden) {
+          window.setTimeout(() => unsubscribe_template(key, true), 0);
+          return;
+        }
         cache.cooldownTimeoutID = window.setTimeout(
           unsubscribe_template,
           20000,
-          key
+          key,
+          false
         );
       }
       break;
@@ -199,14 +209,18 @@ export function unbind_template(
   }
 }
 
-async function unsubscribe_template(key: string) {
+async function unsubscribe_template(key: string, immediate = false) {
   const cache = cachedTemplates[key];
   if (!cache) return;
   if (cache.cooldownTimeoutID) {
     clearTimeout(cache.cooldownTimeoutID);
   }
   if (cache.debug) {
-    console.groupCollapsed("UIX: Unsubscribing template after cooldown");
+    console.groupCollapsed(
+      immediate ? 
+      "UIX: Unsubscribing template immediately" : 
+      "UIX: Unsubscribing template after cooldown"
+    );
     console.log( { 
       template: cache.template, 
       variables: cache.variables,

--- a/src/uix.ts
+++ b/src/uix.ts
@@ -364,7 +364,13 @@ export class Uix extends LitElement {
     this._styles = "";
     this.cancelStyleChild();
     await unbind_template(this._renderer);
-    this.uix_parent?.refresh?.();
+    if (this.uix_parent) {
+      if (this.uix_parent?.isConnected) {
+        this.uix_parent.refresh?.();
+      } else {
+        this.uix_parent._processStylesOnConnect = true;
+      }
+    }
   }
 
   private _style_rendered(result: string) {


### PR DESCRIPTION
Fix 1: Do not refresh parent UIX if is not connected. Rather set that stlyes need to be processed on reconnect.

Fix 2: Ubsubscribe templates immediately if document is hidden. Such unsubscribes come from UIX node disconnects as partial-panel-resolver disconnects the view when document hidden. Next the app may be suspended which means that the unsubscribe after cooldown will happen when the view is reconnected, likely before the node is reconnected so the template will not be in cache but the unsubscribe will fail as the template subscription is no longer valid.