### PR TITLE
docs: register German translation

### DIFF
--- a/docs/translations.json
+++ b/docs/translations.json
@@ -1,4 +1,11 @@
 {
   "schema": 1,
-  "languages": []
+  "languages": [
+    {
+      "code": "de",
+      "name": "Deutsch",
+      "url": "https://opensource.ugso-software.de/projects/uix/",
+      "metadata_url": "https://opensource.ugso-software.de/projects/uix/uix-docs.json"
+    }
+  ]
 }


### PR DESCRIPTION
Adds the independently hosted German UIX documentation to the external translations registry.\n\nTranslation URL: https://opensource.ugso-software.de/projects/uix/\nMetadata URL: https://opensource.ugso-software.de/projects/uix/uix-docs.json\n\nThe translated documentation is maintained outside the canonical UIX repository as requested.