### PR TITLE
docs: register German translation

### DIFF
--- a/docs/translations.json
+++ b/docs/translations.json
@@ -1,4 +1,11 @@
 {
   "schema": 1,
-  "languages": []
+  "languages": [
+    {
+      "code": "de",
+      "name": "Deutsch",
+      "url": "https://opensource.ugso-software.de/projects/uix/",
+      "metadata_url": "https://opensource.ugso-software.de/projects/uix/uix-docs.json"
+    }
+  ]
 }


### PR DESCRIPTION
Registers the external German UIX documentation translation.\n\n- Adds the German translation link to docs/translations.json\n- Uses the published metadata endpoint at https://opensource.ugso-software.de/projects/uix/uix-docs.json\n- The German documentation is maintained externally and marked as an unofficial translation\n- The site footer includes the UIX version information and CC BY 4.0 documentation attribution\n\nNo UIX source or generated documentation files are included in this PR.