### PR TITLE
docs: add German translation curator

### DIFF
--- a/docs/translations.json
+++ b/docs/translations.json
@@ -5,7 +5,8 @@
       "code": "de",
       "name": "Deutsch",
       "url": "https://opensource.ugso-software.de/projects/uix/",
-      "metadata_url": "https://opensource.ugso-software.de/projects/uix/uix-docs.json"
+      "metadata_url": "https://opensource.ugso-software.de/projects/uix/uix-docs.json",
+      "curators": ["rockbaer2007"]
     }
   ]
 }


### PR DESCRIPTION
Adds my GitHub handle as curator for the registered German translation so I can receive translation update notifications.\n\nThis changes only docs/translations.json, following the translation fork maintenance guidance.