### PR TITLE
feat(tooltip): add trigger options and preserve content hover

### DIFF
--- a/docs/source/broker/directives.md
+++ b/docs/source/broker/directives.md
@@ -345,6 +345,16 @@ Use `style` for a flat mapping of CSS properties. This is particularly useful fo
     "--uix-tooltip-max-width": 24ch
 ```
 
+`trigger` accepts Web Awesome's space-separated `hover`, `focus`, `click`, and `manual` activation modes. When `hover` is enabled, the tooltip remains open while the pointer moves from the target into the tooltip body, allowing constrained content to be scrolled. `manual` does not activate automatically; use `open` to set its state when the directive runs.
+
+```yaml
+- type: tooltip
+  for: previous
+  trigger: manual
+  open: true
+  content: This tooltip is opened by the directive
+```
+
 | Key | Type | Default | Description |
 | --- | --- | --- | --- |
 | `for` | string | directive anchor | Target selector, or `previous` for the preceding element-producing directive. |
@@ -354,6 +364,8 @@ Use `style` for a flat mapping of CSS properties. This is particularly useful fo
 | `skidding` | number | `0` | Offset in pixels along the target axis. |
 | `show_delay` | number | `150` | Milliseconds before the tooltip shows. |
 | `hide_delay` | number | `150` | Milliseconds before the tooltip hides. |
+| `trigger` | string | `"hover focus"` | Space-separated activation modes: `hover`, `focus`, `click`, or `manual`. |
+| `open` | boolean | `false` | Set the tooltip's open state when the directive runs. This is particularly useful with `trigger: manual`. |
 | `without_arrow` | boolean | `false` | Hide the directional arrow. |
 | `style` | object | — | Flat map of CSS property names and string or numeric values, set inline on `wa-tooltip`. |
 

--- a/docs/source/forge/sparks/tooltip.md
+++ b/docs/source/forge/sparks/tooltip.md
@@ -56,10 +56,23 @@ Only the **first** element matched by `for` gets the tooltip.
 | `skidding` | number | | `0` | Offset in pixels along the target element's axis. |
 | `show_delay` | number | | `150` | Milliseconds to wait before showing the tooltip. |
 | `hide_delay` | number | | `150` | Milliseconds to wait before hiding the tooltip. |
+| `trigger` | string | | `"hover focus"` | Space-separated activation modes: `hover`, `focus`, `click`, or `manual`. |
+| `open` | boolean | | `false` | Set the tooltip's open state when the spark configuration changes. This is particularly useful with `trigger: manual`. |
 | `without_arrow` | boolean | | `false` | Set to `true` to hide the directional arrow. |
 
 !!! tip
     You can use the [`uix_forge_path()`](../../concepts/dom.md#uix_forge_path0-forge-helper) DOM helper to take the guesswork out of finding the right path for `for`.
+
+When `hover` is enabled, the tooltip remains open while the pointer moves from the target into the tooltip body. This allows content constrained with `--uix-tooltip-max-height` and `--uix-tooltip-overflow: auto` to be scrolled. `manual` does not activate automatically; set `open: true` to open it from the spark configuration.
+
+```yaml
+forge:
+  sparks:
+    - type: tooltip
+      trigger: manual
+      open: true
+      content: This tooltip is opened by the spark configuration
+```
 
 ## Templates in content
 
@@ -160,6 +173,9 @@ element:
 | `--uix-tooltip-border-color` | — | Border color (unset by default). |
 | `--uix-tooltip-border-style` | — | Border style (unset by default). |
 | `--uix-tooltip-max-width` | `30ch` | Maximum width of the tooltip. |
+| `--uix-tooltip-max-height` | `none` | Maximum height of the tooltip body. |
+| `--uix-tooltip-overflow` | `visible` | Overflow behaviour for the tooltip body. Use `auto` to scroll constrained content. |
+| `--uix-tooltip-overflow-wrap` | `normal` | Overflow-wrap behaviour. |
 | `--uix-tooltip-show-duration` | `100ms` | Duration of the show animation. |
 | `--uix-tooltip-hide-duration` | `100ms` | Duration of the hide animation. |
 | `--uix-tooltip-opacity` | `1` | Tooltip opacity. |
@@ -167,4 +183,3 @@ element:
 | `--uix-tooltip-text-align` | `center` | Text alignment. |
 | `--uix-tooltip-text-decoration` | `none` | Text decoration. |
 | `--uix-tooltip-text-transform` | `none` | Text transform. |
-| `--uix-tooltip-overflow-wrap` | `normal` | Overflow-wrap behaviour. |

--- a/src/broker/uix-broker.ts
+++ b/src/broker/uix-broker.ts
@@ -18,10 +18,14 @@ import {
   updateHaTileIcon,
 } from "../helpers/dom/ha-tile-icon";
 import {
+  configureTooltipActivation,
+  normalizeTooltipTrigger,
   stopTooltipHidePropagation,
+  UIX_TOOLTIP_DEFAULT_TRIGGER,
   UIX_TOOLTIP_CONTENT_ATTR,
   UIX_TOOLTIP_CSS,
   UIX_TOOLTIP_STYLE_ATTR,
+  UixTooltipElement,
 } from "../helpers/dom/ha-tooltip";
 import {
   UixBrokerAnchor,
@@ -69,11 +73,12 @@ type BrokerTileIconElement = HTMLElement & {
   uixBrokerStyleProperties?: string[];
 };
 
-type BrokerTooltipElement = HTMLElement & {
+type BrokerTooltipElement = UixTooltipElement & {
   uixBrokerStyleProperties?: string[];
 };
 
 type BrokerTooltip = {
+  cleanupActivation?: () => void;
   element: BrokerTooltipElement;
   target: Element;
 };
@@ -1595,12 +1600,24 @@ export class UixBroker {
     (tooltip as any).distance = this.tooltipNumber(directive.distance, 8, "distance", context);
     (tooltip as any).showDelay = this.tooltipNumber(directive.show_delay, 150, "show_delay", context);
     (tooltip as any).hideDelay = this.tooltipNumber(directive.hide_delay, 150, "hide_delay", context);
+    const trigger = normalizeTooltipTrigger(
+      resolveCaptured(directive.trigger ?? UIX_TOOLTIP_DEFAULT_TRIGGER, context.captured, context.results),
+      "tooltip directive trigger",
+    );
+    let open: boolean | undefined;
+    if (directive.open !== undefined) {
+      open = resolveCaptured(directive.open, context.captured, context.results);
+      if (typeof open !== "boolean") throw new Error("tooltip directive open must be a boolean");
+    }
     const withoutArrow = resolveCaptured(directive.without_arrow ?? false, context.captured, context.results);
     if (typeof withoutArrow !== "boolean") throw new Error("tooltip directive without_arrow must be a boolean");
     tooltip.toggleAttribute("without-arrow", withoutArrow);
     this.clearTooltipStyle(tooltip);
     tooltip.style.setProperty("display", "contents");
     this.applyTooltipStyle(tooltip, directive.style, context);
+    brokerTooltip.cleanupActivation?.();
+    brokerTooltip.cleanupActivation = configureTooltipActivation(tooltip, target, trigger);
+    if (open !== undefined) tooltip.open = open;
 
     if (tooltip.parentNode !== parent) parent.appendChild(tooltip);
     this.refreshRetainedReferenceObservers();
@@ -1664,6 +1681,7 @@ export class UixBroker {
   }
 
   private removeTooltip(directive: UixBrokerDirective, tooltip: BrokerTooltip) {
+    tooltip.cleanupActivation?.();
     tooltip.element.remove();
     this.releaseTooltipTarget(tooltip.target);
     this.tooltips.delete(directive);

--- a/src/forge/sparks/uix-spark-tooltip.ts
+++ b/src/forge/sparks/uix-spark-tooltip.ts
@@ -1,9 +1,13 @@
 import { PropertyValues } from "lit";
 import {
+  configureTooltipActivation,
+  normalizeTooltipTrigger,
   stopTooltipHidePropagation,
+  UIX_TOOLTIP_DEFAULT_TRIGGER,
   UIX_TOOLTIP_CONTENT_ATTR,
   UIX_TOOLTIP_CSS,
   UIX_TOOLTIP_STYLE_ATTR,
+  UixTooltipElement,
 } from "../../helpers/dom/ha-tooltip";
 import { UixForgeSparkBase } from "./uix-spark-base";
 
@@ -18,7 +22,12 @@ export class UixForgeSparkTooltip extends UixForgeSparkBase {
   private withoutArrow: boolean = false;
   private showDelay: number = 150;
   private hideDelay: number = 150;
+  private trigger: string = UIX_TOOLTIP_DEFAULT_TRIGGER;
+  private open: boolean | undefined;
   private _tooltipElement: Element | null = null;
+  private _cleanupActivation?: () => void;
+  private _openWasConfigured = false;
+  private _appliedOpen: boolean | undefined;
 
   constructor(controller: any, config: Record<string, any>) {
     super(controller, config);
@@ -34,11 +43,19 @@ export class UixForgeSparkTooltip extends UixForgeSparkBase {
     this.for = config.for || this.defaultTarget();
     this.content = config.content || "";
     this.placement = config.placement || "top";
-    this.skidding = config.skidding || 0;
-    this.distance = config.distance || 8;
-    this.showDelay = config.show_delay || 150;
-    this.hideDelay = config.hide_delay || 150;
-    this.withoutArrow = config.without_arrow || false;
+    this.skidding = config.skidding ?? 0;
+    this.distance = config.distance ?? 8;
+    this.showDelay = config.show_delay ?? 150;
+    this.hideDelay = config.hide_delay ?? 150;
+    this.withoutArrow = config.without_arrow ?? false;
+    this.trigger = normalizeTooltipTrigger(
+      config.trigger ?? UIX_TOOLTIP_DEFAULT_TRIGGER,
+      "tooltip spark trigger",
+    );
+    if (config.open !== undefined && typeof config.open !== "boolean") {
+      throw new Error("tooltip spark open must be a boolean");
+    }
+    this.open = config.open;
   }
 
   updated(_changedProperties: PropertyValues): void {
@@ -57,10 +74,14 @@ export class UixForgeSparkTooltip extends UixForgeSparkBase {
   }
 
   private _remove() {
+    this._cleanupActivation?.();
+    this._cleanupActivation = undefined;
     if (this._tooltipElement) {
       this._tooltipElement.remove();
       this._tooltipElement = null;
     }
+    this._openWasConfigured = false;
+    this._appliedOpen = undefined;
   }
 
   private async _attach(generation: number) {
@@ -78,14 +99,13 @@ export class UixForgeSparkTooltip extends UixForgeSparkBase {
     // If our tracked tooltip is no longer in this parent, remove it and start fresh
     const existingInParent = ((parent as Element).querySelector?.("wa-tooltip") as any)?.for == element.id;
     if (this._tooltipElement && !existingInParent) {
-      this._tooltipElement.remove();
-      this._tooltipElement = null;
+      this._remove();
     }
 
     const isNew = !this._tooltipElement;
-    let tooltip = this._tooltipElement as any;
+    let tooltip = this._tooltipElement as UixTooltipElement | null;
     if (!tooltip) {
-      tooltip = document.createElement("wa-tooltip");
+      tooltip = document.createElement("wa-tooltip") as UixTooltipElement;
       tooltip.for = element.id;
       tooltip.style.setProperty("display", "contents");
       stopTooltipHidePropagation(tooltip);
@@ -128,6 +148,18 @@ export class UixForgeSparkTooltip extends UixForgeSparkBase {
     } else {
       tooltip.removeAttribute("without-arrow");
     }
+    this._cleanupActivation?.();
+    this._cleanupActivation = configureTooltipActivation(tooltip, element, this.trigger);
+
+    const openConfigured = this.open !== undefined;
+    if (
+      (openConfigured && (!this._openWasConfigured || this._appliedOpen !== this.open)) ||
+      (!openConfigured && this._openWasConfigured)
+    ) {
+      tooltip.open = this.open ?? false;
+    }
+    this._openWasConfigured = openConfigured;
+    this._appliedOpen = this.open;
 
     // Only insert into the DOM when newly created
     if (isNew) {

--- a/src/helpers/dom/ha-tooltip.ts
+++ b/src/helpers/dom/ha-tooltip.ts
@@ -1,6 +1,22 @@
 /** Shared UIX tooltip styling for Home Assistant's wa-tooltip component. */
 export const UIX_TOOLTIP_CONTENT_ATTR = "data-uix-tooltip-content";
 export const UIX_TOOLTIP_STYLE_ATTR = "data-uix-tooltip-style";
+export const UIX_TOOLTIP_DEFAULT_TRIGGER = "hover focus";
+
+const UIX_TOOLTIP_TRIGGERS = new Set(["click", "focus", "hover", "manual"]);
+
+export type UixTooltipElement = HTMLElement & {
+  distance: number;
+  for: string | null;
+  hideDelay: number;
+  open: boolean;
+  placement: string;
+  showDelay: number;
+  skidding: number;
+  trigger: string;
+  hide(): Promise<unknown> | undefined;
+  show(): Promise<unknown> | undefined;
+};
 
 export const UIX_TOOLTIP_CSS = `
   wa-tooltip {
@@ -44,6 +60,9 @@ export const UIX_TOOLTIP_CSS = `
     text-decoration: var(--uix-tooltip-text-decoration, none);
     text-transform: var(--uix-tooltip-text-transform, none);
     overflow-wrap: var(--uix-tooltip-overflow-wrap, normal);
+    max-height: var(--uix-tooltip-max-height, none);
+    height: max-content;
+    overflow: var(--uix-tooltip-overflow, visible);
   }`;
 
 /**
@@ -55,4 +74,82 @@ export function stopTooltipHidePropagation(tooltip: HTMLElement) {
   tooltip.addEventListener("wa-after-hide", (event) => {
     if (event.target === tooltip) event.stopPropagation();
   });
+}
+
+/** Normalize and validate Web Awesome's space-separated tooltip triggers. */
+export function normalizeTooltipTrigger(value: unknown, name = "tooltip trigger"): string {
+  if (typeof value !== "string") {
+    throw new Error(`${name} must be a string`);
+  }
+  const triggers = value.trim().split(/\s+/).filter(Boolean);
+  if (!triggers.length || triggers.some((trigger) => !UIX_TOOLTIP_TRIGGERS.has(trigger))) {
+    throw new Error(`${name} must contain only click, focus, hover, or manual`);
+  }
+  return triggers.join(" ");
+}
+
+/**
+ * Backport Web Awesome 3.9's reliable hover-boundary handling.
+ *
+ * Home Assistant's current Web Awesome version tests `:hover` during mouseout,
+ * which can briefly be false when entering slotted tooltip content. Remove only
+ * the native hover trigger and drive it through the public show/hide methods;
+ * click and focus remain under Web Awesome's control.
+ */
+export function configureTooltipActivation(
+  tooltip: UixTooltipElement,
+  target: Element,
+  trigger: string,
+): () => void {
+  const triggers = trigger.split(" ");
+  const managesHover = triggers.includes("hover");
+  const nativeTriggers = triggers.filter((value) => value !== "hover");
+  tooltip.trigger = managesHover ? nativeTriggers.join(" ") || "manual" : trigger;
+  if (!managesHover) return () => undefined;
+
+  const controller = new AbortController();
+  let showTimeout: number | undefined;
+  let hideTimeout: number | undefined;
+
+  const clearShowTimeout = () => {
+    if (showTimeout === undefined) return;
+    clearTimeout(showTimeout);
+    showTimeout = undefined;
+  };
+  const clearHideTimeout = () => {
+    if (hideTimeout === undefined) return;
+    clearTimeout(hideTimeout);
+    hideTimeout = undefined;
+  };
+  const isWithinTooltip = (value: EventTarget | null) =>
+    value instanceof Node && (target.contains(value) || tooltip.contains(value));
+  const handleMouseOver = (event: MouseEvent) => {
+    clearHideTimeout();
+    if (isWithinTooltip(event.relatedTarget) || tooltip.open) return;
+    clearShowTimeout();
+    showTimeout = window.setTimeout(() => {
+      showTimeout = undefined;
+      void tooltip.show();
+    }, tooltip.showDelay);
+  };
+  const handleMouseOut = (event: MouseEvent) => {
+    if (isWithinTooltip(event.relatedTarget)) return;
+    clearShowTimeout();
+    clearHideTimeout();
+    hideTimeout = window.setTimeout(() => {
+      hideTimeout = undefined;
+      void tooltip.hide();
+    }, tooltip.hideDelay);
+  };
+  const options = { signal: controller.signal };
+  target.addEventListener("mouseover", handleMouseOver as EventListener, options);
+  target.addEventListener("mouseout", handleMouseOut as EventListener, options);
+  tooltip.addEventListener("mouseover", handleMouseOver, options);
+  tooltip.addEventListener("mouseout", handleMouseOut, options);
+
+  return () => {
+    controller.abort();
+    clearShowTimeout();
+    clearHideTimeout();
+  };
 }

--- a/tests/ha-config/uix/test_broker_tooltip.yaml
+++ b/tests/ha-config/uix/test_broker_tooltip.yaml
@@ -24,6 +24,7 @@ uix_broker:
         for: previous
         content: "Go to tools"
         placement: top
+        trigger: hover focus
         hide_delay: 20000
         style:
           "--uix-tooltip-border-color": "rgba(0, 0, 0, 0.8)"
@@ -54,6 +55,8 @@ uix_broker:
         for: previous
         content: "Go to tools"
         placement: bottom
+        trigger: manual
+        open: true
         without_arrow: true
         hide_delay: 20000
         style:

--- a/tests/visual/scenarios/broker/05_broker_tooltip.yaml
+++ b/tests/visual/scenarios/broker/05_broker_tooltip.yaml
@@ -46,6 +46,11 @@ assertions:
     selector: wa-tooltip
     property: "--uix-tooltip-border-style"
     expected: "solid"
+  - type: object_property_text_equals
+    root: "ha-list-item-button#sidebar-panel-home"
+    selector: wa-tooltip
+    property: trigger
+    expected: focus
   - type: element_present
     root: "ha-list-item-button#sidebar-panel-energy"
     selector: wa-tooltip
@@ -64,6 +69,16 @@ assertions:
     selector: wa-tooltip
     property: "--uix-tooltip-content-color"
     expected: "white"
+  - type: object_property_text_equals
+    root: "ha-list-item-button#sidebar-panel-energy"
+    selector: wa-tooltip
+    property: trigger
+    expected: manual
+  - type: object_property_text_equals
+    root: "ha-list-item-button#sidebar-panel-energy"
+    selector: wa-tooltip
+    property: open
+    expected: "true"
   - type: snapshot
     name: "61_broker_tooltip"
     threshold: 0.01

--- a/tests/visual/scenarios/forge/02_forge_tooltip.yaml
+++ b/tests/visual/scenarios/forge/02_forge_tooltip.yaml
@@ -19,6 +19,7 @@ card:
       - type: tooltip
         for: hui-tile-card
         content: "This is a UIX tooltip"
+        trigger: hover focus
   element:
     type: tile
     entity: "light.bed_light"
@@ -28,6 +29,12 @@ interactions:
   - type: hover
     selector: uix-forge
     settle_ms: 800
+  # Regression: Web Awesome 3.7 hides on this transition because its :hover
+  # check races when the pointer enters slotted tooltip content.
+  - type: hover
+    root: uix-forge
+    selector: div[data-uix-tooltip-content]
+    settle_ms: 300
 
 assertions:
   - type: element_present
@@ -40,6 +47,19 @@ assertions:
     root: uix-forge
     selector: wa-tooltip
     expected: "This is a UIX tooltip"
+
+  - type: object_property_text_equals
+    root: uix-forge
+    selector: wa-tooltip
+    property: open
+    expected: "true"
+
+  # UIX owns the configured hover trigger while Web Awesome retains focus.
+  - type: object_property_text_equals
+    root: uix-forge
+    selector: wa-tooltip
+    property: trigger
+    expected: focus
 
   # Snapshot is taken after hover so the tooltip is visible.
   - type: snapshot


### PR DESCRIPTION
Expose Web Awesome trigger and open options for Broker and Forge tooltips.

Backport Web Awesome 3.9 relatedTarget hover handling so tooltips remain open while the target or tooltip content is hovered.